### PR TITLE
fixes an assumption that the i18n path is the base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 logs
 *.log
 *.iml
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-##### v1.0.0 
+## Unreleased
+
+- fixes an assumption that the i18n path is the base path. (it is the path to the locales directory)
+
+## v1.0.0
 
 * FIX: add legit unit test to resolve https://github.com/krakenjs/construx-makara-amdify/issues/2
 * REFACTOR: remove dependency on `makara-writer-amd` module (deprecating)
 
-##### v0.0.1
+## v0.0.1
 
 First release of construx-makara-amdify

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var path = require('path');
 var iferr = require('iferr');
 var spundle = require('spundle');
 var moduleBuilder = function (appRoot, m, cb) {
-    spundle(path.resolve(appRoot, 'locales'), m[2], m[1], iferr(cb, function (out) {
+    spundle(path.resolve(appRoot), m[2], m[1], iferr(cb, function (out) {
         cb(null, 'define("_languagepack", function () { return ' + JSON.stringify(out) + '; });');
     }));
 };
@@ -37,9 +37,9 @@ module.exports = function (options) {
             return callback(new Error('The locale part xx-XX was not found in the filePath'));
         }
         moduleBuilder(args.i18n.contentPath, locale, function (err, out) {
-           if (err !== null) {
-               return callback(err);
-           }
+            if (err !== null) {
+                return callback(err);
+            }
             callback(null, out);
         });
 

--- a/test/index.js
+++ b/test/index.js
@@ -27,16 +27,16 @@ var test = require('tap').test,
   fs = require('fs');
 
 test('construx-makara-amdify', function (t) {
+    t.plan(2);
 
     t.test('processes a good request for an amd languagepack file', function (t) {
-        t.plan(1);
         //process good languagepack request
         var args = {
             context: {
                 filePath: '/en-US/_languagepack.js'
             },
             i18n: {
-                contentPath: path.resolve(__dirname)
+                contentPath: path.resolve(__dirname, 'locales')
             }
         };
         amdify(null, args, function (err, out) {
@@ -44,8 +44,8 @@ test('construx-makara-amdify', function (t) {
             t.end();
         });
     });
+
     t.test('processes a bad request for an amd languagepack file', function (t) {
-        t.plan(1);
         //process good languagepack request
         var args = {
             context: {


### PR DESCRIPTION
if the i18n path is

```
"i18n": {
        "contentPath": "path:./locales",
        "fallback": "en-US"
}
```

the path that `construx-makara-amdify` assumes is ${path}/locales/locales` causing an obvious issue with pathing.